### PR TITLE
Fix string interpolation issues

### DIFF
--- a/src/gen_help.mbt
+++ b/src/gen_help.mbt
@@ -29,11 +29,11 @@ pub fn Parser::gen_help_message(
     let name_upper = name.to_upper()
     let nargs = arg.nargs().unwrap()
     let label = if nargs is Nargs::Fixed(1) {
-      "<\{name_upper}>"
+      "<{name_upper}>"
     } else if nargs.is_exceeded(2) {
-      "[\{name_upper}]"
+      "[{name_upper}]"
     } else {
-      "[\{name_upper}]..."
+      "[{name_upper}]..."
     }
     builder.write_char(' ')
     builder.write_string(label)
@@ -51,7 +51,7 @@ pub fn Parser::gen_help_message(
       .maximum()
       .unwrap()
     for name, subcmd in subcmds.iter2() {
-      builder.write_string("  \{name}  ")
+      builder.write_string("  {name}  ")
       for _ in 0..<(max_length - name.char_length()) {
         builder.write_char(' ')
       }
@@ -62,7 +62,7 @@ pub fn Parser::gen_help_message(
   }
   if arg_pos_mark is Some((label, help)) {
     builder.write_string("Arguments:\n")
-    builder.write_string("  \{label}  \{help}\n\n")
+    builder.write_string("  {label}  {help}\n\n")
   }
   write_args(builder, "Options", args, {}, true)
   if not(global_args.is_empty()) {
@@ -80,19 +80,19 @@ fn write_args(
   cull_args : Map[String, Arg],
   include_help : Bool
 ) -> Unit {
-  builder.write_string("\{title}:\n")
+  builder.write_string("{title}:\n")
   let options = []
   for name, arg in the_args.iter2() {
     guard not(cull_args.contains(name)) else { continue }
     guard not(arg is Positional(..)) else { continue }
     let short_string = match arg.short() {
-      Some(short) => "-\{short},"
+      Some(short) => "-{short},"
       None => "   "
     }
     let long_string = if arg is Flag(_) {
-      "--\{name}"
+      "--{name}"
     } else {
-      "--\{name} <\{name.to_upper()}>"
+      "--{name} <{name.to_upper()}>"
     }
     let length = short_string.char_length() + long_string.char_length()
     options.push((short_string, long_string, length, arg.common().help))
@@ -103,7 +103,7 @@ fn write_args(
   let max_length = options.iter().map(fn(item) { item.2 }).maximum().unwrap()
   for item in options {
     let (short_string, long_string, length, help) = item
-    builder.write_string("  \{short_string} \{long_string}  ")
+    builder.write_string("  {short_string} {long_string}  ")
     for _ in 0..<(max_length - length) {
       builder.write_char(' ')
     }

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -73,7 +73,7 @@ pub fn[V : Value] Parser::parse(
       [.. "-", .. rest] => {
         guard rest.char_length() == 1 else {
           raise InvalidArgumentName(
-            "Invalid short argument name \{cli_arg} for \{cmd_name}",
+            "Invalid short argument name {cli_arg} for {cmd_name}",
           )
         }
         let short_char = rest.char_at(0)
@@ -100,7 +100,7 @@ pub fn[V : Value] Parser::parse(
         if arg.choices() is Some(choices) {
           if choices.size() > 0 && not(choices.contains(value_string)) {
             raise InvalidArgumentValue(
-              "Invalid argument value for \{cmd_name} => \{name}, value=\{value_string}, choices=\{choices}",
+              "Invalid argument value for {cmd_name} => {name}, value={value_string}, choices={choices}",
             )
           }
         }
@@ -110,7 +110,7 @@ pub fn[V : Value] Parser::parse(
         let nargs = arg.nargs().unwrap()
         if nargs.is_exceeded(new_length) {
           raise TooManyArgs(
-            "Argument length limit: \{nargs}, current length: \{new_length}",
+            "Argument length limit: {nargs}, current length: {new_length}",
           )
         }
         if (not(positional_arg.is_empty()) || not(subcmds.is_empty())) &&
@@ -149,7 +149,7 @@ pub fn[V : Value] Parser::parse(
       }
       value =>
         raise InvalidSubCommandName(
-          "Invalid sub-command name \{value} for \{cmd_name}",
+          "Invalid sub-command name {value} for {cmd_name}",
         )
     }
   }
@@ -198,12 +198,12 @@ fn[V : Value] handle_current_arg(
 ) -> (String, Arg)?!ParserError {
   guard new_arg is Some((name, arg)) else {
     raise InvalidArgumentName(
-      "Invalid argument name \{cli_arg} for \{cmd_name}",
+      "Invalid argument name {cli_arg} for {cmd_name}",
     )
   }
   if arg is Positional(..) {
     raise InvalidPositionalAsNamed(
-      "Invalid use positional argument as name argument: \{cli_arg} for \{cmd_name} ",
+      "Invalid use positional argument as name argument: {cli_arg} for {cmd_name} ",
     )
   }
   if arg is Flag(store~, ..) {
@@ -230,7 +230,7 @@ fn analysis_and_check_spec(
     if positional {
       if not(subcmds.is_empty()) {
         raise InvalidSpec(
-          "Invalid argument spec: sub-commands(parent=\{cmd_name}) and positional argument(\{name}) are not allowed at the same time",
+          "Invalid argument spec: sub-commands(parent={cmd_name}) and positional argument({name}) are not allowed at the same time",
         )
       } else {
         positional_arg = Some((name, arg))
@@ -238,7 +238,7 @@ fn analysis_and_check_spec(
     }
     if positional && has_positional {
       raise InvalidSpec(
-        "Invalid argument, only one positional argument is allowed, second=\{name}",
+        "Invalid argument, only one positional argument is allowed, second={name}",
       )
     }
     has_positional = has_positional || positional
@@ -250,7 +250,7 @@ fn analysis_and_check_spec(
         not(short_char.is_ascii_alphabetic()) &&
         not(short_char.is_ascii_digit()) {
         raise InvalidSpec(
-          "Invalid argument spec: parent-cmd=\{cmd_name}, name=\{name}, short=\{short_char}, only 0-9,a-z,A-Z is allowed",
+          "Invalid argument spec: parent-cmd={cmd_name}, name={name}, short={short_char}, only 0-9,a-z,A-Z is allowed",
         )
       }
     }
@@ -258,7 +258,7 @@ fn analysis_and_check_spec(
       for value in get_defaults(arg, env_vars) {
         if not(choices.contains(value.to_string())) {
           raise InvalidSpec(
-            "Invalid argument, name=\{name}, default value=\{value} not in choices=\{choices}",
+            "Invalid argument, name={name}, default value={value} not in choices={choices}",
           )
         }
       }
@@ -295,7 +295,7 @@ fn[V : Value] complete_level(
       // flag and named argument can only presented in final subcommand
       if (arg is Flag(_) || arg is Named(_)) && length > 0 && not(final_subcmd) {
         raise InvalidArgumentValueLength(
-          "Invalid argument: \{name}, flag/named argument can only presented in final level",
+          "Invalid argument: {name}, flag/named argument can only presented in final level",
         )
       }
       if arg is Flag(store~, ..) {
@@ -305,7 +305,7 @@ fn[V : Value] complete_level(
         } else if length > 1 {
           // TODO: support multiple flag in the future?
           raise InvalidArgumentValueLength(
-            "Invalid flag argument length=\{length} > 1",
+            "Invalid flag argument length={length} > 1",
           )
         }
       } else {
@@ -329,20 +329,20 @@ fn[V : Value] complete_level(
             if not(final_subcmd) {
               if length != 0 {
                 raise InvalidArgumentValueLength(
-                  "Invalid positional argument length=\{length}, expected: 0 (has subcommand)",
+                  "Invalid positional argument length={length}, expected: 0 (has subcommand)",
                 )
               }
             } else {
               nargs_error = Some(
                 InvalidArgumentValueLength(
-                  "Invalid positional argument length=\{length}, limit: \{nargs}",
+                  "Invalid positional argument length={length}, limit: {nargs}",
                 ),
               )
             }
           } else if final_subcmd {
             nargs_error = Some(
               InvalidArgumentValueLength(
-                "Invalid name argument length=\{length}, limit: \{nargs}, final: \{final_subcmd}",
+                "Invalid name argument length={length}, limit: {nargs}, final: {final_subcmd}",
               ),
             )
           }

--- a/src/parser_test.mbt
+++ b/src/parser_test.mbt
@@ -174,14 +174,14 @@ impl Value for CustomValue with set_flag(self, name : String, value : Bool) -> U
   match self.subcmd {
     None => {
       guard name == "debug" else {
-        raise ParserError::InvalidArgumentName("Invalid flag \{name}=\{value}")
+        raise ParserError::InvalidArgumentName("Invalid flag {name}={value}")
       }
       self.debug = value
     }
     Some(SubCommand1(positional_args~, ..)) => {
       guard name == "verbose" else {
         raise ParserError::InvalidArgumentName(
-          "Invalid subcmd1 flag \{name}=\{value}",
+          "Invalid subcmd1 flag {name}={value}",
         )
       }
       self.subcmd = Some(SubCommand1(verbose=value, positional_args~))
@@ -202,7 +202,7 @@ impl Value for CustomValue with add_value(
         "arg1" => self.arg1 = value
         _ =>
           raise ParserError::InvalidArgumentName(
-            "Invalid argument name \{name}",
+            "Invalid argument name {name}",
           )
       }
     Some(SubCommand1(positional_args~, ..)) =>
@@ -210,14 +210,14 @@ impl Value for CustomValue with add_value(
         "arg2" => {
           guard @strconv.parse_uint?(value) is Ok(value) else {
             raise ParserError::InvalidArgumentValue(
-              "Invalid value \{value} for argument \{name}",
+              "Invalid value {value} for argument {name}",
             )
           }
           positional_args.push(value)
         }
         _ =>
           raise ParserError::InvalidArgumentName(
-            "Invalid argument name \{name}",
+            "Invalid argument name {name}",
           )
       }
   }
@@ -230,7 +230,7 @@ impl Value for CustomValue with select_subcmd(self, name : String) -> CustomValu
       self.subcmd = Some(SubCommand1(verbose=false, positional_args=[]))
     _ =>
       raise ParserError::InvalidSubCommandName(
-        "Invalid subcommand name \{name}",
+        "Invalid subcommand name {name}",
       )
   }
   self

--- a/src/subcmd.mbt
+++ b/src/subcmd.mbt
@@ -1,7 +1,7 @@
 ///|
 pub(all) struct SubCommand {
   args : Map[String, Arg]
-  /// If there is sub-commands position, positional arguments in currently level is forbiden.
+  /// If there is sub-commands position, positional arguments in currently level is forbidden.
   subcmds : Map[String, SubCommand]
   help : String
 }

--- a/src/value.mbt
+++ b/src/value.mbt
@@ -43,11 +43,11 @@ pub fn[T : BasicValue] SimpleValue::get_one(
   name : String
 ) -> T!ParserError {
   guard self.args.get(name) is Some(values) else {
-    raise InvalidArgumentValue("Value not found for: \{name}")
+    raise InvalidArgumentValue("Value not found for: {name}")
   }
   guard values.length() == 1 else {
     raise InvalidArgumentValueLength(
-      "Invalid argument length: \{values.length()}, expected=1, name=\{name}",
+      "Invalid argument length: {values.length()}, expected=1, name={name}",
     )
   }
   match T::parse?(values[0]) {
@@ -65,7 +65,7 @@ pub fn[T : BasicValue] SimpleValue::get_option(
   let length = values.length()
   guard length <= 1 else {
     raise InvalidArgumentValueLength(
-      "Invalid argument length: \{length}, expected<=1, name=\{name}",
+      "Invalid argument length: {length}, expected<=1, name={name}",
     )
   }
   guard values.get(0) is Some(value) else { return None }
@@ -137,7 +137,7 @@ pub(open) trait Value {
 ///|
 impl Value with set_flag(_self, name : String, _value : Bool) -> Unit!ParserError {
   raise ParserError::InvalidArgumentName(
-    "Invalid argument name \{name}, unimplemented",
+    "Invalid argument name {name}, unimplemented",
   )
 }
 
@@ -149,14 +149,14 @@ impl Value with add_value(
   _positional : Bool
 ) -> Unit!ParserError {
   raise ParserError::InvalidArgumentValue(
-    "Invalid argument name=\{name}, value=\{value}, unimplemented",
+    "Invalid argument name={name}, value={value}, unimplemented",
   )
 }
 
 ///|
 impl Value with select_subcmd(_self, subcmd : String) -> Self!ParserError {
   raise ParserError::InvalidSubCommandName(
-    "Invalid sub-command \{subcmd}, unimplemented",
+    "Invalid sub-command {subcmd}, unimplemented",
   )
 }
 


### PR DESCRIPTION
This PR fixes string interpolation issues in the help message generation code. 
  Replaced incorrect usage of escaped interpolation patterns (e.g., `\{name_upper}`) with the proper `{name_upper}` syntax in gen_help.mbt ,parser_test.mbt,parser.mbt,value.mbt and `write_args` so that variable values are correctly substituted in the generated help messages.
