### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/arg.mbt
+++ b/src/arg.mbt
@@ -34,7 +34,7 @@ pub fn Arg::flag(
   store~ : Bool = true,
   global~ : Bool = false,
   env_var~ : String = "",
-  help~ : String = ""
+  help~ : String = "",
 ) -> Arg {
   let common = { help, env_var }
   Flag(short~, store~, global~, common~)
@@ -49,7 +49,7 @@ pub fn Arg::named(
   global~ : Bool = false,
   value_delimiter~ : String = ",",
   env_var~ : String = "",
-  help~ : String = ""
+  help~ : String = "",
 ) -> Arg {
   let common = { help, env_var }
   Named(short~, nargs~, choices~, defaults~, global~, value_delimiter~, common~)
@@ -62,7 +62,7 @@ pub fn Arg::positional(
   defaults~ : ArrayView[String] = [],
   value_delimiter~ : String = ",",
   env_var~ : String = "",
-  help~ : String = ""
+  help~ : String = "",
 ) -> Arg {
   let common = { help, env_var }
   Positional(nargs~, choices~, defaults~, value_delimiter~, common~)

--- a/src/clap.mbti
+++ b/src/clap.mbti
@@ -1,0 +1,111 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "TheWaWaR/clap"
+
+import(
+  "moonbitlang/core/hashmap"
+  "moonbitlang/core/hashset"
+  "moonbitlang/core/strconv"
+)
+
+// Values
+
+// Errors
+pub(all) suberror ParserError {
+  InvalidArgumentName(String)
+  InvalidSubCommandName(String)
+  InvalidPositionalAsNamed(String)
+  InvalidArgumentValue(String)
+  InvalidArgumentValueLength(String)
+  TooManyArgs(String)
+  InvalidSpec(String)
+}
+impl Show for ParserError
+
+// Types and methods
+pub(all) enum Arg {
+  Flag(short~ : Char, store~ : Bool, global~ : Bool, common~ : CommonFields)
+  Named(short~ : Char, nargs~ : Nargs, choices~ : @hashset.T[String], defaults~ : ArrayView[String], global~ : Bool, value_delimiter~ : String, common~ : CommonFields)
+  Positional(nargs~ : Nargs, choices~ : @hashset.T[String], defaults~ : ArrayView[String], value_delimiter~ : String, common~ : CommonFields)
+}
+fn Arg::choices(Self) -> @hashset.T[String]?
+fn Arg::common(Self) -> CommonFields
+fn Arg::defaults(Self) -> ArrayView[String]
+fn Arg::flag(short? : Char, store? : Bool, global? : Bool, env_var? : String, help? : String) -> Self
+fn Arg::is_global(Self) -> Bool
+fn Arg::named(short? : Char, nargs? : Nargs, choices? : @hashset.T[String], defaults? : ArrayView[String], global? : Bool, value_delimiter? : String, env_var? : String, help? : String) -> Self
+fn Arg::nargs(Self) -> Nargs?
+fn Arg::positional(nargs? : Nargs, choices? : @hashset.T[String], defaults? : ArrayView[String], value_delimiter? : String, env_var? : String, help? : String) -> Self
+fn Arg::short(Self) -> Char?
+fn Arg::value_delimiter(Self) -> String?
+
+pub struct CommonFields {
+  env_var : String
+  help : String
+}
+
+pub(all) enum Nargs {
+  Any
+  One
+  Fixed(UInt)
+  AtLeast(UInt)
+  AtMost(UInt)
+  Range(UInt, UInt)
+}
+fn Nargs::is_exceeded(Self, UInt) -> Bool
+fn Nargs::is_valid_length(Self, UInt) -> Bool
+impl Eq for Nargs
+impl Show for Nargs
+
+pub(all) struct Parser {
+  prog : String
+  args : Map[String, Arg]
+  subcmds : Map[String, SubCommand]
+  description : String
+}
+fn Parser::gen_help_message(Self, Array[String], Map[String, Arg]) -> String
+fn Parser::new(prog? : String, args? : Map[String, Arg], subcmds? : Map[String, SubCommand], description? : String) -> Self
+fn[V : Value] Parser::parse(Self, V, ArrayView[String], env_vars? : Map[String, String]) -> String? raise ParserError
+
+pub(all) struct SimpleValue {
+  name : String
+  args : @hashmap.T[String, Array[String]]
+  flags : @hashmap.T[String, Bool]
+  positional_args : Array[String]
+  mut subcmd : SimpleValue?
+}
+fn[T : BasicValue] SimpleValue::get_array(Self, String) -> Array[T] raise ParserError
+fn SimpleValue::get_flag(Self, String) -> Bool?
+fn[T : BasicValue] SimpleValue::get_one(Self, String) -> T raise ParserError
+fn[T : BasicValue] SimpleValue::get_option(Self, String) -> T? raise ParserError
+fn[T : BasicValue] SimpleValue::get_positional(Self) -> Array[T] raise ParserError
+fn SimpleValue::new(String) -> Self
+impl Value for SimpleValue
+impl Eq for SimpleValue
+impl Show for SimpleValue
+
+pub(all) struct SubCommand {
+  args : Map[String, Arg]
+  subcmds : Map[String, SubCommand]
+  help : String
+}
+fn SubCommand::new(args? : Map[String, Arg], subcmds? : Map[String, Self], help? : String) -> Self
+
+// Type aliases
+
+// Traits
+pub(open) trait BasicValue {
+  parse(String) -> Self raise @strconv.StrConvError
+}
+impl BasicValue for Int
+impl BasicValue for Int64
+impl BasicValue for UInt
+impl BasicValue for UInt64
+impl BasicValue for Double
+impl BasicValue for String
+
+pub(open) trait Value {
+  set_flag(Self, String, Bool) -> Unit raise ParserError = _
+  add_value(Self, String, String, Bool) -> Unit raise ParserError = _
+  select_subcmd(Self, String) -> Self raise ParserError = _
+}
+

--- a/src/gen_help.mbt
+++ b/src/gen_help.mbt
@@ -2,7 +2,7 @@
 pub fn Parser::gen_help_message(
   self : Parser,
   subcmd_chains : Array[String],
-  global_args : Map[String, Arg]
+  global_args : Map[String, Arg],
 ) -> String {
   let builder = StringBuilder::new(size_hint=32)
   builder.write_string("Usage: ")
@@ -78,7 +78,7 @@ fn write_args(
   title : String,
   the_args : Map[String, Arg],
   cull_args : Map[String, Arg],
-  include_help : Bool
+  include_help : Bool,
 ) -> Unit {
   builder.write_string("\{title}:\n")
   let options = []

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -87,7 +87,7 @@ pub fn[V : Value] Parser::parse(
             )
           }
         } else {
-          let short_char = rest.char_at(0)
+          let short_char = rest.get_char(0).unwrap()
           if short_char == 'h' {
             return Some(self.gen_help_message(subcmd_chains, global_args))
           }

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -3,6 +3,7 @@
 //  * support Arg::required_if/required_unless (implement use user provider parser closure)
 //  * add more error tests
 //  * add more docs
+
 ///|
 pub(all) struct Parser {
   /// The program name
@@ -18,13 +19,13 @@ pub fn Parser::new(
   prog~ : String = "PROG",
   args~ : Map[String, Arg] = {},
   subcmds~ : Map[String, SubCommand] = {},
-  description~ : String = ""
+  description~ : String = "",
 ) -> Parser {
   { prog, args, subcmds, description }
 }
 
 ///|
-pub(all) type! ParserError {
+pub(all) suberror ParserError {
   InvalidArgumentName(String)
   InvalidSubCommandName(String)
   InvalidPositionalAsNamed(String)
@@ -39,8 +40,8 @@ pub fn[V : Value] Parser::parse(
   self : Parser,
   value : V,
   cli_args : ArrayView[String],
-  env_vars~ : Map[String, String] = {}
-) -> String?!ParserError {
+  env_vars~ : Map[String, String] = {},
+) -> String? raise ParserError {
   let mut cmd_name = self.prog
   let subcmd_chains = [cmd_name]
   let global_args : Map[String, Arg] = {}
@@ -51,7 +52,7 @@ pub fn[V : Value] Parser::parse(
   let mut current_value = value
   let mut current_arg : (String, Arg)? = None
   let mut nargs_error : ParserError? = None
-  if analysis_and_check_spec!(cmd_name, args, global_args, subcmds, env_vars)
+  if analysis_and_check_spec(cmd_name, args, global_args, subcmds, env_vars)
     is Some(rv) {
     positional_arg = Some(rv)
   }
@@ -67,10 +68,10 @@ pub fn[V : Value] Parser::parse(
           .map_or_else(fn() { global_args.get(name) }, fn(x) { Some(x) })
           .map(fn(arg) { (name, arg) })
         if new_arg.is_empty() && positional_arg is Some(arg) {
-          current_value.add_value!(arg.0, cli_arg, true)
+          current_value.add_value(arg.0, cli_arg, true)
           update_args_length(args_length, arg.0)
         } else {
-          current_arg = handle_current_arg!(
+          current_arg = handle_current_arg(
             current_value, cli_arg, new_arg, cmd_name, args_length,
           )
         }
@@ -78,7 +79,7 @@ pub fn[V : Value] Parser::parse(
       [.. "-", .. rest] =>
         if rest.char_length() != 1 {
           if positional_arg is Some(arg) {
-            current_value.add_value!(arg.0, cli_arg, true)
+            current_value.add_value(arg.0, cli_arg, true)
             update_args_length(args_length, arg.0)
           } else {
             raise InvalidArgumentName(
@@ -102,10 +103,10 @@ pub fn[V : Value] Parser::parse(
               fn(x) { Some(x) },
             )
           if new_arg.is_empty() && positional_arg is Some(arg) {
-            current_value.add_value!(arg.0, cli_arg, true)
+            current_value.add_value(arg.0, cli_arg, true)
             update_args_length(args_length, arg.0)
           } else {
-            current_arg = handle_current_arg!(
+            current_arg = handle_current_arg(
               current_value, cli_arg, new_arg, cmd_name, args_length,
             )
           }
@@ -119,7 +120,7 @@ pub fn[V : Value] Parser::parse(
             )
           }
         }
-        current_value.add_value!(name, value_string, false)
+        current_value.add_value(name, value_string, false)
         update_args_length(args_length, name)
         let new_length = args_length.get_or_default(name, 0)
         let nargs = arg.nargs().unwrap()
@@ -136,7 +137,7 @@ pub fn[V : Value] Parser::parse(
       }
       // == SubCommand ==
       value if subcmds.get(value) is Some(subcmd) => {
-        if complete_level!(
+        if complete_level(
             args, global_args, args_length, current_value, env_vars, false,
           )
           is Some(err) {
@@ -148,9 +149,9 @@ pub fn[V : Value] Parser::parse(
         args = subcmd.args
         subcmds = subcmd.subcmds
         args_length.clear()
-        current_value = current_value.select_subcmd!(cmd_name)
+        current_value = current_value.select_subcmd(cmd_name)
         current_arg = None
-        if analysis_and_check_spec!(
+        if analysis_and_check_spec(
             cmd_name, args, global_args, subcmds, env_vars,
           )
           is Some(rv) {
@@ -160,7 +161,7 @@ pub fn[V : Value] Parser::parse(
       // == Positional argument ==
       value_string if positional_arg is Some(arg) => {
         let name = arg.0
-        current_value.add_value!(name, value_string, true)
+        current_value.add_value(name, value_string, true)
         update_args_length(args_length, name)
       }
       value =>
@@ -169,7 +170,7 @@ pub fn[V : Value] Parser::parse(
         )
     }
   }
-  if complete_level!(
+  if complete_level(
       args, global_args, args_length, current_value, env_vars, true,
     )
     is Some(err) {
@@ -184,7 +185,7 @@ pub fn[V : Value] Parser::parse(
 ///|
 fn get_defaults(
   arg : Arg,
-  env_vars : Map[String, String]
+  env_vars : Map[String, String],
 ) -> Iter[@string.View] {
   let common = arg.common()
   if not(common.env_var.is_empty()) &&
@@ -199,7 +200,7 @@ fn get_defaults(
 ///|
 fn update_args_length(
   args_length : @hashmap.T[String, UInt],
-  name : String
+  name : String,
 ) -> Unit {
   args_length.set(name, args_length.get_or_default(name, 0) + 1)
 }
@@ -210,8 +211,8 @@ fn[V : Value] handle_current_arg(
   cli_arg : String,
   new_arg : (String, Arg)?,
   cmd_name : String,
-  args_length : @hashmap.T[String, UInt]
-) -> (String, Arg)?!ParserError {
+  args_length : @hashmap.T[String, UInt],
+) -> (String, Arg)? raise ParserError {
   guard new_arg is Some((name, arg)) else {
     raise InvalidArgumentName(
       "Invalid argument name \{cli_arg} for \{cmd_name}",
@@ -223,7 +224,7 @@ fn[V : Value] handle_current_arg(
     )
   }
   if arg is Flag(store~, ..) {
-    current_value.set_flag!(name, store)
+    current_value.set_flag(name, store)
     update_args_length(args_length, name)
     // Only one flag can be in a single level, so reset current_arg
     None
@@ -238,8 +239,8 @@ fn analysis_and_check_spec(
   args : Map[String, Arg],
   global_args : Map[String, Arg],
   subcmds : Map[String, SubCommand],
-  env_vars : Map[String, String]
-) -> (String, Arg)?!ParserError {
+  env_vars : Map[String, String],
+) -> (String, Arg)? raise ParserError {
   let mut has_positional = false
   let mut positional_arg = None
   for name, arg in args.iter2() {
@@ -286,6 +287,7 @@ fn analysis_and_check_spec(
 
 // * set default value if missing
 // * check argument value length is valid
+
 ///|
 fn[V : Value] complete_level(
   args : Map[String, Arg],
@@ -293,8 +295,8 @@ fn[V : Value] complete_level(
   args_length : @hashmap.T[String, UInt],
   current_value : V,
   env_vars : Map[String, String],
-  final_subcmd : Bool
-) -> ParserError?!ParserError {
+  final_subcmd : Bool,
+) -> ParserError? raise ParserError {
   let mut nargs_error : ParserError? = None
   let all_args = if final_subcmd {
     [(args, false), (global_args, true)]
@@ -331,7 +333,7 @@ fn[V : Value] complete_level(
           } else {
             not(store)
           }
-          current_value.set_flag!(name, value)
+          current_value.set_flag(name, value)
           update_args_length(args_length, name)
         } else if length > 1 {
           // TODO: support multiple flag in the future?
@@ -345,11 +347,7 @@ fn[V : Value] complete_level(
         //   * non-final level named argument
         if length == 0 && not(positional && not(final_subcmd)) {
           for default_value in get_defaults(arg, env_vars) {
-            current_value.add_value!(
-              name,
-              default_value.to_string(),
-              positional,
-            )
+            current_value.add_value(name, default_value.to_string(), positional)
             update_args_length(args_length, name)
             length += 1
           }

--- a/src/parser_test.mbt
+++ b/src/parser_test.mbt
@@ -208,12 +208,13 @@ impl Value for CustomValue with add_value(
     Some(SubCommand1(positional_args~, ..)) =>
       match name {
         "arg2" => {
-          guard @strconv.parse_uint?(value) is Ok(value) else {
+          let parsed_value = try? @strconv.parse_uint(value)
+          guard parsed_value is Ok(uint_value) else {
             raise ParserError::InvalidArgumentValue(
               "Invalid value \{value} for argument \{name}",
             )
           }
-          positional_args.push(value)
+          positional_args.push(uint_value)
         }
         _ =>
           raise ParserError::InvalidArgumentName(

--- a/src/parser_test.mbt
+++ b/src/parser_test.mbt
@@ -4,16 +4,16 @@ test "parse simple named argument" {
     "arg1": Arg::named(short='a', nargs=Fixed(1), help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--arg1", "abc"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 1)
-  assert_eq!(value.args.get("arg1").unwrap(), ["abc"])
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["--arg1", "abc"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 1)
+  assert_eq(value.args.get("arg1").unwrap(), ["abc"])
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.is_empty(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS]
     #|
@@ -21,7 +21,7 @@ test "parse simple named argument" {
     #|  -a, --arg1 <ARG1>  Argument 1
     #|  -h, --help         Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -30,15 +30,15 @@ test "parse simple positional argument" {
     "arg1": Arg::positional(nargs=Fixed(1), help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["abc"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 0)
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args, ["abc"])
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["abc"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 0)
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args, ["abc"])
+  assert_eq(value.subcmd.is_empty(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS] <ARG1>
     #|
@@ -48,7 +48,7 @@ test "parse simple positional argument" {
     #|Options:
     #|  -h, --help  Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -57,15 +57,15 @@ test "parse simple flag argument" {
     "arg1": Arg::flag(short='a', help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--arg1"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 0)
-  assert_eq!(value.flags.get("arg1").unwrap(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["--arg1"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 0)
+  assert_eq(value.flags.get("arg1").unwrap(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.is_empty(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS]
     #|
@@ -73,7 +73,7 @@ test "parse simple flag argument" {
     #|  -a, --arg1  Argument 1
     #|  -h, --help  Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -85,15 +85,15 @@ test "parse simple subcmd" {
     ),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["subcmd1", "--arg1"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 0)
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.unwrap().flags.get("arg1").unwrap(), true)
+  let help_message = parser.parse(value, ["subcmd1", "--arg1"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 0)
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.unwrap().flags.get("arg1").unwrap(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS] <COMMAND>
     #|
@@ -103,9 +103,9 @@ test "parse simple subcmd" {
     #|Options:
     #|  -h, --help  Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["subcmd1", "--help"]).unwrap()
+  let help_message = parser.parse(value, ["subcmd1", "--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG subcmd1 [OPTIONS]
     #|
@@ -113,7 +113,7 @@ test "parse simple subcmd" {
     #|  -a, --arg1  Argument 1
     #|  -h, --help  Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -122,14 +122,14 @@ test "parser short named argument" {
     "arg1": Arg::named(short='a', nargs=Fixed(1), help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["-a", "abc"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 1)
-  assert_eq!(value.args.get("arg1").unwrap(), ["abc"])
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["-a", "abc"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 1)
+  assert_eq(value.args.get("arg1").unwrap(), ["abc"])
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.is_empty(), true)
 }
 
 ///|
@@ -138,15 +138,15 @@ test "parse short flag argument" {
     "arg1": Arg::flag(short='a', help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["-a"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 0)
-  assert_eq!(value.flags.get("arg1").unwrap(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["-a"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 0)
+  assert_eq(value.flags.get("arg1").unwrap(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.is_empty(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["-h"]).unwrap()
+  let help_message = parser.parse(value, ["-h"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS]
     #|
@@ -154,7 +154,7 @@ test "parse short flag argument" {
     #|  -a, --arg1  Argument 1
     #|  -h, --help  Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -170,7 +170,7 @@ enum CustomCommands {
 } derive(Show, Eq)
 
 ///|
-impl Value for CustomValue with set_flag(self, name : String, value : Bool) -> Unit!ParserError {
+impl Value for CustomValue with set_flag(self, name : String, value : Bool) -> Unit raise ParserError {
   match self.subcmd {
     None => {
       guard name == "debug" else {
@@ -194,8 +194,8 @@ impl Value for CustomValue with add_value(
   self,
   name : String,
   value : String,
-  _positional : Bool
-) -> Unit!ParserError {
+  _positional : Bool,
+) -> Unit raise ParserError {
   match self.subcmd {
     None =>
       match name {
@@ -224,7 +224,7 @@ impl Value for CustomValue with add_value(
 }
 
 ///|
-impl Value for CustomValue with select_subcmd(self, name : String) -> CustomValue!ParserError {
+impl Value for CustomValue with select_subcmd(self, name : String) -> CustomValue raise ParserError {
   match name {
     "subcmd1" =>
       self.subcmd = Some(SubCommand1(verbose=false, positional_args=[]))
@@ -254,13 +254,13 @@ test "parse custom value" {
     },
   )
   let value = CustomValue::{ debug: false, arg1: "", subcmd: None }
-  let help_message = parser.parse!(value, ["--debug", "--arg1", "value1"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.debug, true)
-  assert_eq!(value.arg1, "value1")
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["--debug", "--arg1", "value1"])
+  assert_eq(help_message, None)
+  assert_eq(value.debug, true)
+  assert_eq(value.arg1, "value1")
+  assert_eq(value.subcmd.is_empty(), true)
   let value = CustomValue::{ debug: false, arg1: "", subcmd: None }
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS] <COMMAND>
     #|
@@ -272,20 +272,20 @@ test "parse custom value" {
     #|  -a, --arg1 <ARG1>  Argument 1
     #|  -h, --help         Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
   let value = CustomValue::{ debug: false, arg1: "", subcmd: None }
-  let help_message = parser.parse!(value, [
+  let help_message = parser.parse(value, [
     "subcmd1", "--verbose", "33", "44", "55",
   ])
-  assert_eq!(help_message, None)
-  assert_eq!(value.debug, false)
-  assert_eq!(value.arg1, "")
-  assert_eq!(
+  assert_eq(help_message, None)
+  assert_eq(value.debug, false)
+  assert_eq(value.arg1, "")
+  assert_eq(
     value.subcmd.unwrap(),
     SubCommand1(verbose=true, positional_args=[33, 44, 55]),
   )
   let value = CustomValue::{ debug: false, arg1: "", subcmd: None }
-  let help_message = parser.parse!(value, ["subcmd1", "--help"]).unwrap()
+  let help_message = parser.parse(value, ["subcmd1", "--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG subcmd1 [OPTIONS] [ARG2]...
     #|
@@ -296,7 +296,7 @@ test "parse custom value" {
     #|  -v, --verbose  Verbose
     #|  -h, --help     Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -322,21 +322,21 @@ test "simple global argument" {
     },
   )
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, [
+  let help_message = parser.parse(value, [
     "subcmd1", "--debug", "--arg1", "value1", "33", "44", "55",
   ])
-  assert_eq!(help_message, None)
+  assert_eq(help_message, None)
   let subcmd1 = value.subcmd.unwrap()
-  assert_eq!(subcmd1.flags.get("debug").unwrap(), true)
-  assert_eq!(subcmd1.args.get("arg1").unwrap(), ["value1"])
-  assert_eq!(subcmd1.positional_args, ["33", "44", "55"])
-  assert_eq!(subcmd1.get_flag("debug").unwrap(), true)
-  assert_eq!(subcmd1.get_one!("arg1"), "value1")
-  assert_eq!(subcmd1.get_option!("arg1").unwrap(), "value1")
-  assert_eq!(subcmd1.get_array!("arg1"), ["value1"])
-  assert_eq!(subcmd1.get_positional!(), [(33 : UInt), 44, 55])
+  assert_eq(subcmd1.flags.get("debug").unwrap(), true)
+  assert_eq(subcmd1.args.get("arg1").unwrap(), ["value1"])
+  assert_eq(subcmd1.positional_args, ["33", "44", "55"])
+  assert_eq(subcmd1.get_flag("debug").unwrap(), true)
+  assert_eq(subcmd1.get_one("arg1"), "value1")
+  assert_eq(subcmd1.get_option("arg1").unwrap(), "value1")
+  assert_eq(subcmd1.get_array("arg1"), ["value1"])
+  assert_eq(subcmd1.get_positional(), [(33 : UInt), 44, 55])
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["subcmd1", "--help"]).unwrap()
+  let help_message = parser.parse(value, ["subcmd1", "--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG subcmd1 [OPTIONS] [ARG2]...
     #|
@@ -351,7 +351,7 @@ test "simple global argument" {
     #|  -d, --debug        Debug
     #|  -a, --arg1 <ARG1>  Argument 1
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -365,16 +365,16 @@ test "simple env vars" {
     ),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, [], env_vars={ "ENV_ARG1": "ijk,xyz" })
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 1)
-  assert_eq!(value.args.get("arg1").unwrap(), ["ijk", "xyz"])
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args.is_empty(), true)
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, [], env_vars={ "ENV_ARG1": "ijk,xyz" })
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 1)
+  assert_eq(value.args.get("arg1").unwrap(), ["ijk", "xyz"])
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args.is_empty(), true)
+  assert_eq(value.subcmd.is_empty(), true)
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["--help"]).unwrap()
+  let help_message = parser.parse(value, ["--help"]).unwrap()
   let expected_help_message =
     #|Usage: PROG [OPTIONS]
     #|
@@ -382,7 +382,7 @@ test "simple env vars" {
     #|  -a, --arg1 <ARG1>  Argument 1
     #|  -h, --help         Print help
     #|
-  assert_eq!(help_message, expected_help_message)
+  assert_eq(help_message, expected_help_message)
 }
 
 ///|
@@ -392,12 +392,12 @@ test "parse special positional argument with -" {
     "arg2": Arg::named(short='A', nargs=AtMost(1), help="Argument 2"),
   })
   let value = SimpleValue::new(parser.prog)
-  let help_message = parser.parse!(value, ["-", "-2", "xx", "-A", "333"])
-  assert_eq!(help_message, None)
-  assert_eq!(value.name, "PROG")
-  assert_eq!(value.args.size(), 1)
-  assert_eq!(value.args.get("arg2").unwrap(), ["333"])
-  assert_eq!(value.flags.is_empty(), true)
-  assert_eq!(value.positional_args, ["-", "-2", "xx"])
-  assert_eq!(value.subcmd.is_empty(), true)
+  let help_message = parser.parse(value, ["-", "-2", "xx", "-A", "333"])
+  assert_eq(help_message, None)
+  assert_eq(value.name, "PROG")
+  assert_eq(value.args.size(), 1)
+  assert_eq(value.args.get("arg2").unwrap(), ["333"])
+  assert_eq(value.flags.is_empty(), true)
+  assert_eq(value.positional_args, ["-", "-2", "xx"])
+  assert_eq(value.subcmd.is_empty(), true)
 }

--- a/src/parser_test_error.mbt
+++ b/src/parser_test_error.mbt
@@ -5,7 +5,7 @@ test "named argument length exceeded" {
   })
   let value = SimpleValue::new(parser.prog)
   let result = parser.parse?(value, ["--arg1", "v1", "v2", "v3"])
-  assert_eq!(result.unwrap_err().to_string().contains("TooManyArgs"), true)
+  assert_eq(result.unwrap_err().to_string().contains("TooManyArgs"), true)
 }
 
 ///|
@@ -15,8 +15,11 @@ test "flag argument duplicated" {
   })
   let value = SimpleValue::new(parser.prog)
   let result = parser.parse?(value, ["--arg1", "--arg1"])
-  assert_eq!(
-    result.unwrap_err().to_string().contains("Invalid flag argument length: 2 > 1"),
+  assert_eq(
+    result
+    .unwrap_err()
+    .to_string()
+    .contains("Invalid flag argument length: 2 > 1"),
     true,
   )
 }

--- a/src/parser_test_error.mbt
+++ b/src/parser_test_error.mbt
@@ -4,7 +4,7 @@ test "named argument length exceeded" {
     "arg1": Arg::named(short='a', nargs=Fixed(2), help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let result = parser.parse?(value, ["--arg1", "v1", "v2", "v3"])
+  let result = try? parser.parse(value, ["--arg1", "v1", "v2", "v3"])
   assert_eq(result.unwrap_err().to_string().contains("TooManyArgs"), true)
 }
 
@@ -14,7 +14,7 @@ test "flag argument duplicated" {
     "arg1": Arg::flag(short='a', help="Argument 1"),
   })
   let value = SimpleValue::new(parser.prog)
-  let result = parser.parse?(value, ["--arg1", "--arg1"])
+  let result = try? parser.parse(value, ["--arg1", "--arg1"])
   assert_eq(
     result
     .unwrap_err()

--- a/src/subcmd.mbt
+++ b/src/subcmd.mbt
@@ -10,7 +10,7 @@ pub(all) struct SubCommand {
 pub fn SubCommand::new(
   args~ : Map[String, Arg] = {},
   subcmds~ : Map[String, SubCommand] = {},
-  help~ : String = ""
+  help~ : String = "",
 ) -> SubCommand {
   { args, subcmds, help }
 }

--- a/src/value.mbt
+++ b/src/value.mbt
@@ -25,8 +25,8 @@ pub fn SimpleValue::get_flag(self : SimpleValue, name : String) -> Bool? {
 
 ///| Get the positional argument values
 pub fn[T : BasicValue] SimpleValue::get_positional(
-  self : SimpleValue
-) -> Array[T]!ParserError {
+  self : SimpleValue,
+) -> Array[T] raise ParserError {
   let out = []
   for value in self.positional_args {
     match T::parse?(value) {
@@ -40,8 +40,8 @@ pub fn[T : BasicValue] SimpleValue::get_positional(
 ///| Get exactly one value by the argument name
 pub fn[T : BasicValue] SimpleValue::get_one(
   self : SimpleValue,
-  name : String
-) -> T!ParserError {
+  name : String,
+) -> T raise ParserError {
   guard self.args.get(name) is Some(values) else {
     raise InvalidArgumentValue("Value not found for: \{name}")
   }
@@ -59,8 +59,8 @@ pub fn[T : BasicValue] SimpleValue::get_one(
 ///| Get one/zero value by the argument name
 pub fn[T : BasicValue] SimpleValue::get_option(
   self : SimpleValue,
-  name : String
-) -> T?!ParserError {
+  name : String,
+) -> T? raise ParserError {
   guard self.args.get(name) is Some(values) else { return None }
   let length = values.length()
   guard length <= 1 else {
@@ -78,8 +78,8 @@ pub fn[T : BasicValue] SimpleValue::get_option(
 ///| Get multiple values by the argument name
 pub fn[T : BasicValue] SimpleValue::get_array(
   self : SimpleValue,
-  name : String
-) -> Array[T]!ParserError {
+  name : String,
+) -> Array[T] raise ParserError {
   guard self.args.get(name) is Some(values) else { return [] }
   let out = []
   for value in values {
@@ -93,49 +93,48 @@ pub fn[T : BasicValue] SimpleValue::get_array(
 
 ///|
 pub(open) trait BasicValue {
-  parse(input : String) -> Self!@strconv.StrConvError
+  parse(input : String) -> Self raise @strconv.StrConvError
 }
 
 ///|
-pub impl BasicValue for String with parse(input : String) -> String!@strconv.StrConvError {
+pub impl BasicValue for String with parse(input : String) -> String raise @strconv.StrConvError {
   input
 }
 
 ///|
-pub impl BasicValue for Double with parse(input : String) -> Double!@strconv.StrConvError {
-  @strconv.parse_double!(input)
+pub impl BasicValue for Double with parse(input : String) -> Double raise @strconv.StrConvError {
+  @strconv.parse_double(input)
 }
 
 ///|
-pub impl BasicValue for Int with parse(input : String) -> Int!@strconv.StrConvError {
-  @strconv.parse_int!(input)
+pub impl BasicValue for Int with parse(input : String) -> Int raise @strconv.StrConvError {
+  @strconv.parse_int(input)
 }
 
 ///|
-pub impl BasicValue for Int64 with parse(input : String) -> Int64!@strconv.StrConvError {
-  @strconv.parse_int64!(input)
+pub impl BasicValue for Int64 with parse(input : String) -> Int64 raise @strconv.StrConvError {
+  @strconv.parse_int64(input)
 }
 
 ///|
-pub impl BasicValue for UInt with parse(input : String) -> UInt!@strconv.StrConvError {
-  @strconv.parse_uint!(input)
+pub impl BasicValue for UInt with parse(input : String) -> UInt raise @strconv.StrConvError {
+  @strconv.parse_uint(input)
 }
 
 ///|
-pub impl BasicValue for UInt64 with parse(input : String) -> UInt64!@strconv.StrConvError {
-  @strconv.parse_uint64!(input)
+pub impl BasicValue for UInt64 with parse(input : String) -> UInt64 raise @strconv.StrConvError {
+  @strconv.parse_uint64(input)
 }
 
 ///|
 pub(open) trait Value {
-  set_flag(Self, name : String, value : Bool) -> Unit!ParserError = _
-  add_value(Self, name : String, value : String, positional : Bool) ->
-       Unit!ParserError = _
-  select_subcmd(Self, subcmd : String) -> Self!ParserError = _
+  set_flag(Self, name : String, value : Bool) -> Unit raise ParserError = _
+  add_value(Self, name : String, value : String, positional : Bool) -> Unit raise ParserError = _
+  select_subcmd(Self, subcmd : String) -> Self raise ParserError = _
 }
 
 ///|
-impl Value with set_flag(_self, name : String, _value : Bool) -> Unit!ParserError {
+impl Value with set_flag(_self, name : String, _value : Bool) -> Unit raise ParserError {
   raise ParserError::InvalidArgumentName(
     "Invalid argument name \{name}, unimplemented",
   )
@@ -146,22 +145,22 @@ impl Value with add_value(
   _self,
   name : String,
   value : String,
-  _positional : Bool
-) -> Unit!ParserError {
+  _positional : Bool,
+) -> Unit raise ParserError {
   raise ParserError::InvalidArgumentValue(
     "Invalid argument name=\{name}, value=\{value}, unimplemented",
   )
 }
 
 ///|
-impl Value with select_subcmd(_self, subcmd : String) -> Self!ParserError {
+impl Value with select_subcmd(_self, subcmd : String) -> Self raise ParserError {
   raise ParserError::InvalidSubCommandName(
     "Invalid sub-command \{subcmd}, unimplemented",
   )
 }
 
 ///|
-pub impl Value for SimpleValue with set_flag(self, name : String, value : Bool) -> Unit!ParserError {
+pub impl Value for SimpleValue with set_flag(self, name : String, value : Bool) -> Unit raise ParserError {
   self.flags.set(name, value)
 }
 
@@ -170,8 +169,8 @@ pub impl Value for SimpleValue with add_value(
   self,
   name : String,
   value : String,
-  positional : Bool
-) -> Unit!ParserError {
+  positional : Bool,
+) -> Unit raise ParserError {
   if positional {
     self.positional_args.push(value)
   } else if self.args.get(name) is Some(values) {
@@ -182,7 +181,7 @@ pub impl Value for SimpleValue with add_value(
 }
 
 ///|
-pub impl Value for SimpleValue with select_subcmd(self, subcmd : String) -> SimpleValue!ParserError {
+pub impl Value for SimpleValue with select_subcmd(self, subcmd : String) -> SimpleValue raise ParserError {
   match self.subcmd {
     Some(subcmd_value) => subcmd_value
     None => {

--- a/src/value.mbt
+++ b/src/value.mbt
@@ -29,7 +29,7 @@ pub fn[T : BasicValue] SimpleValue::get_positional(
 ) -> Array[T] raise ParserError {
   let out = []
   for value in self.positional_args {
-    match T::parse?(value) {
+    match (try? T::parse(value)) {
       Err(err) => raise InvalidArgumentValue(err.to_string())
       Ok(v) => out.push(v)
     }
@@ -50,7 +50,7 @@ pub fn[T : BasicValue] SimpleValue::get_one(
       "Invalid argument length: \{values.length()}, expected=1, name=\{name}",
     )
   }
-  match T::parse?(values[0]) {
+  match (try? T::parse(values[0])) {
     Err(err) => raise InvalidArgumentValue(err.to_string())
     Ok(v) => v
   }
@@ -69,7 +69,7 @@ pub fn[T : BasicValue] SimpleValue::get_option(
     )
   }
   guard values.get(0) is Some(value) else { return None }
-  match T::parse?(value) {
+  match (try? T::parse(value)) {
     Err(err) => raise InvalidArgumentValue(err.to_string())
     Ok(v) => Some(v)
   }
@@ -83,7 +83,7 @@ pub fn[T : BasicValue] SimpleValue::get_array(
   guard self.args.get(name) is Some(values) else { return [] }
   let out = []
   for value in values {
-    match T::parse?(value) {
+    match (try? T::parse(value)) {
       Err(err) => raise InvalidArgumentValue(err.to_string())
       Ok(v) => out.push(v)
     }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Fixed the following deprecation warnings:
- Replaced deprecated `char_at()` method with `get_char().unwrap()`
- Replaced deprecated `f?(..)` syntax with `try? f(..)` for error conversion to Result

All tests continue to pass after these changes.